### PR TITLE
Create app as early as possible to allow commands that depend on the app...

### DIFF
--- a/flaskext/script.py
+++ b/flaskext/script.py
@@ -663,6 +663,7 @@ class Manager(object):
 
         app_parser = self.create_parser(prog)
         app_namespace, remaining_args = app_parser.parse_known_args(app_args)
+        app = self.create_app(**app_namespace.__dict__)
 
         for arg in help_args:
             if arg in args:
@@ -676,8 +677,6 @@ class Manager(object):
         else:
             command_namespace = command_parser.parse_args(remaining_args)
             positional_args = []
-
-        app = self.create_app(**app_namespace.__dict__)
 
         command.handle(app, *positional_args, **command_namespace.__dict__)
 


### PR DESCRIPTION
... to glean options from it. Otherwise, command parsers of those commands will fail or return inappropriate results.

I've actually come across this problem when trying to use Flask-Celery with Flask-Script. Flask-Celery's [celeryd command tries to get options dynamically from the current celery app instance.](https://github.com/ask/flask-celery/blob/5407cfde604928acf92513fd26a4a838eef4c337/flask_celery.py#L103) Which in turn is typically created by the create_app factory.

No new tests added, existing tests passed.
