### PR TITLE
only depend on argparse if python older than 2.7

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,7 @@ Links
 
 
 """
+import sys
 from setuptools import setup
 
 # Hack to prevent stupid TypeError: 'NoneType' object is not callable error on
@@ -21,6 +22,10 @@ try:
     import multiprocessing
 except ImportError:
     pass
+
+install_requires = ['Flask']
+if sys.version_info < (2, 7):
+    install_requires += ['argparse']
 
 setup(
     name='Flask-Script',
@@ -39,10 +44,7 @@ setup(
     test_suite='nose.collector',
     zip_safe=False,
     platforms='any',
-    install_requires=[
-        'Flask',
-        'argparse',
-    ],
+    install_requires=install_requires,
     tests_require=[
         'nose',
     ],


### PR DESCRIPTION
Fixes this warning:

```
PATH_TO_VIRTUALENV/lib/python2.7/site-packages/babel/__init__.py:33: UserWarning: Module argparse was already imported from /usr/local/Python-2.7.3/lib/python2.7/argparse.pyc, but PATH_TO_VIRTUALENV/lib/python2.7/site-packages is being added to sys.path
  from pkg_resources import get_distribution, ResolutionError
```
