### PR TITLE
Add Group, a simple way to group arguments

### DIFF
--- a/flask_script/__init__.py
+++ b/flask_script/__init__.py
@@ -10,10 +10,10 @@ import argparse
 
 from flask import Flask
 
-from .commands import Option, InvalidCommand, Command, Server, Shell
+from .commands import Group, Option, InvalidCommand, Command, Server, Shell
 from .cli import prompt, prompt_pass, prompt_bool, prompt_choices
 
-__all__ = ["Command", "Shell", "Server", "Manager", "Option",
+__all__ = ["Command", "Shell", "Server", "Manager", "Group", "Option",
            "prompt", "prompt_pass", "prompt_bool", "prompt_choices"]
 
 

--- a/flask_script/commands.py
+++ b/flask_script/commands.py
@@ -17,6 +17,48 @@ class InvalidCommand(Exception):
     pass
 
 
+class Group(object):
+    """
+    Stores argument groups and mutually exclusive groups for
+    `ArgumentParser.add_argument_group <http://argparse.googlecode.com/svn/trunk/doc/other-methods.html#argument-groups>`
+    or `ArgumentParser.add_mutually_exclusive_group <http://argparse.googlecode.com/svn/trunk/doc/other-methods.html#add_mutually_exclusive_group>`.
+
+    Note: The title and description params cannot be used with the exclusive
+    or required params.
+
+    :param options: A list of Option classes to add to this group
+    :param title: A string to use as the title of the argument group
+    :param description: A string to use as the description of the argument
+                        group
+    :param exclusive: A boolean indicating if this is an argument group or a
+                      mutually exclusive group
+    :param required: A boolean indicating if this mutually exclusive group
+                     must have an option selected
+    """
+
+    def __init__(self, *options, **kwargs):
+        self.option_list = options
+
+        self.title = kwargs.pop("title", None)
+        self.description = kwargs.pop("description", None)
+        self.exclusive = kwargs.pop("exclusive", None)
+        self.required = kwargs.pop("required", None)
+
+        if ((self.title or self.description) and
+                (self.required or self.exclusive)):
+            raise TypeError("title and/or description cannot be used with "
+                                "required and/or exclusive.")
+
+        super(Group, self).__init__(**kwargs)
+
+    def get_options(self):
+        """
+        By default, returns self.option_list. Override if you
+        need to do instance-specific configuration.
+        """
+        return self.option_list
+
+
 class Option(object):
     """
     Stores positional and optional arguments for `ArgumentParser.add_argument
@@ -75,7 +117,20 @@ class Command(object):
                                          description=self.description)
 
         for option in self.get_options():
-            parser.add_argument(*option.args, **option.kwargs)
+            if isinstance(option, Group):
+                if option.exclusive:
+                    group = parser.add_mutually_exclusive_group(
+                                required=option.required,
+                            )
+                else:
+                    group = parser.add_argument_group(
+                                title=option.title,
+                                description=option.description,
+                            )
+                for opt in option.get_options():
+                    group.add_argument(*opt.args, **opt.kwargs)
+            else:
+                parser.add_argument(*option.args, **option.kwargs)
 
         return parser
 


### PR DESCRIPTION
This adds a Group class which makes it possible to specify either argument groups or mutually exclusive groups (Both a part of argparse) on a class. Examples:

```
class Mycommand(Command):

    option_list = [
        Option("--foo),
        Group(
            Option("--bar"),
            Option("--wat"),
            title="My Arguments",
            description="a Description of my arguments!",
        ),
        Group(
            Option("--type-one"),
            Option("--type-two"),
            exclusive=True,
        ),
    ]
```
