### PR TITLE
Nasty little bug in Clean class which deletes **all** files in directory :)

### DIFF
--- a/flask_script/commands.py
+++ b/flask_script/commands.py
@@ -368,7 +368,7 @@ class Clean(Command):
     def run(self):
         for dirpath, dirnames, filenames in os.walk('.'):
             for filename in filenames:
-                if '.pyc' or '.pyo' in filename:
+                if filename.endswith('.pyc') or filename.endswith('.pyo'):
                     full_pathname = os.path.join(dirpath, filename)
                     print 'Removing %s' % full_pathname
                     os.remove(full_pathname)


### PR DESCRIPTION
Hey there, awesome Flask plugin! :)

Unfortunately I've found a rather nasty bug in the Clean class that caught me by surprise when it deleted all files in my current project.

Please find my testing below, performed on Ubuntu 12.04 with PyPy 1.9 (and also tested with CPython 2.7).

My manage.py is minimal:

``` python
#!/usr/bin/env python
from flask.ext.script import Manager
from flask.ext.script.commands import Clean
from app import app

manager = Manager(app)
manager.add_command('clean', Clean())

if __name__ == "__main__":
    manager.run()
```

Run with original version:

``` bash
(webdev-pypy)fots@fotsies-ubprecise-01:~/test-clean$ ll
total 12
-rw-rw-r-- 1 fots fots   0 Jan  9 14:55 a-file.txt
-rw-rw-r-- 1 fots fots 103 Jan  9 14:54 app.py
-rw-rw-r-- 1 fots fots 381 Jan  9 14:56 app.pyc
-rwxrwxr-x 1 fots fots 231 Jan  9 14:55 manage.py
(webdev-pypy)fots@fotsies-ubprecise-01:~/test-clean$ ./manage.py clean
Removing ./a-file.txt
Removing ./app.pyc
Removing ./manage.py
Removing ./app.py
(webdev-pypy)fots@fotsies-ubprecise-01:~/test-clean$ ll
total 0
```

Run with modified version:

``` bash
(webdev-pypy)fots@fotsies-ubprecise-01:~/test-clean$ ll
total 12
-rw-rw-r-- 1 fots fots   0 Jan  9 14:55 a-file.txt
-rw-rw-r-- 1 fots fots 103 Jan  9 14:54 app.py
-rw-rw-r-- 1 fots fots 381 Jan  9 14:57 app.pyc
-rwxrwxr-x 1 fots fots 231 Jan  9 14:55 manage.py
(webdev-pypy)fots@fotsies-ubprecise-01:~/test-clean$ ./manage.py clean
Removing ./app.pyc
(webdev-pypy)fots@fotsies-ubprecise-01:~/test-clean$ ll
total 8
-rw-rw-r-- 1 fots fots   0 Jan  9 14:55 a-file.txt
-rw-rw-r-- 1 fots fots 103 Jan  9 14:54 app.py
-rwxrwxr-x 1 fots fots 231 Jan  9 14:55 manage.py
```

All the best :)
Fotis
