### PR TITLE
debug parameter no longer passed in from flask_script

### DIFF
--- a/flask_script/commands.py
+++ b/flask_script/commands.py
@@ -355,7 +355,6 @@ class Server(Command):
 
         app.run(host=host,
                 port=port,
-                debug=app.config.get('DEBUG', use_debugger),
                 use_debugger=use_debugger,
                 use_reloader=use_reloader,
                 threaded=threaded,


### PR DESCRIPTION
The debug parameter now defaults to False in flask, so the
app.config.get('DEBUG', use_debugger) will never default to
use_debugger as the 'DEBUG' key will always exist.
Better to leave this option for the user to set it up in the app's
config.
