### PR TITLE
Fix exception on missing command

### DIFF
--- a/flask_script/__init__.py
+++ b/flask_script/__init__.py
@@ -314,7 +314,11 @@ class Manager(object):
 
         ## get the handle function and remove it from parsed options
         kwargs = app_namespace.__dict__
-        handle = kwargs.pop('func_handle')
+        if 'func_handle' in kwargs:
+            handle = kwargs.pop('func_handle')
+        else:
+            app_parser.print_help()
+            return 2
 
         ## get only safe config options
         app_config_keys = [action.dest for action in app_parser._actions

--- a/tests.py
+++ b/tests.py
@@ -652,7 +652,7 @@ class TestSubManager:
         code = run('manage.py sub_manager', lambda: manager.run())
         out, err = capsys.readouterr()
         assert code == 2
-        assert 'too few arguments' in err
+        assert 'usage: manage.py' in out
 
         code = run('manage.py sub_manager -h', lambda: manager.run())
         out, err = capsys.readouterr()


### PR DESCRIPTION
This is just a quick fix that prints help message instead of `too few arguments`. I don't know currently how to make it look nicer.
