### PR TITLE
Allow exception to bubble up naturally during Shell make_context callback

### DIFF
--- a/flask_script/__init__.py
+++ b/flask_script/__init__.py
@@ -362,7 +362,5 @@ class Manager(object):
             result = self.handle(sys.argv[0], sys.argv[1:])
         except SystemExit as e:
             result = e.code
-        except Exception as e:
-            raise e
 
         sys.exit(result or 0)


### PR DESCRIPTION
Currently if an exception occurs during the make_context function passed to Shell, it is just being caught and re-raises the exception object, which loses the original stack trace of the exception. These two lines should just be removed completely, as any exception that is cannot be handled should just be allowed to bubble up naturally.
