### PR TITLE
Initialize Flask debug variable to the correct setting

### DIFF
--- a/flask_script/commands.py
+++ b/flask_script/commands.py
@@ -362,6 +362,7 @@ class Server(Command):
 
         app.run(host=host,
                 port=port,
+                debug=use_debugger,
                 use_debugger=use_debugger,
                 use_reloader=use_reloader,
                 threaded=threaded,


### PR DESCRIPTION
The debug state in Flask is never changed, only Werkzeug gets set with the correct debug state. Because if that the debugger is not activated.
