### PR TITLE
Add a few features to allow for command auto detection

### DIFF
--- a/flask_script/__init__.py
+++ b/flask_script/__init__.py
@@ -205,6 +205,9 @@ class Manager(object):
         if isinstance(command, Manager):
             command.parent = self
 
+        if isinstance(command, type):
+            command = command()
+
         namespace = kwargs.get('namespace')
         if not namespace:
             namespace = getattr(command, 'namespace', None)

--- a/tests.py
+++ b/tests.py
@@ -228,6 +228,13 @@ class TestManager:
         assert isinstance(ns._commands['hello'], SimpleCommand)
         assert isinstance(ns._commands['world'], SimpleCommand)
 
+    def test_add_command_class(self):
+
+        manager = Manager(self.app)
+        manager.add_command('simple', SimpleCommand)
+
+        assert isinstance(manager._commands['simple'], SimpleCommand)
+
     def test_simple_command_decorator(self, capsys):
 
         manager = Manager(self.app)


### PR DESCRIPTION
First off; great project here. I wanted to take it and use it for command auto-detection (eg. django and its `INSTALLED_APPS`). There were a couple of things missing to make that go cleanly.
- Commands can no declare their own name via a class attribute
- Commands can namespace themselves into automatic sub-managers
- `add_command` can accept a command class in which case it just constructs it with no args

``` python
from flask.ext.script import Command
class Some(Command):
   name = 'some'
   namespace = 'something'
   def run(self):
      print('Hello')

manager.add_command(Some)
```

Adding the above command will result in a sub manager `something` having the `some` command.

``` sh
$ python manage.py something some
Hello
```

The end-result of all this is that the following works somewhat cleanly (to automatically add all commands from every module or package listed in the `COMPONENTS` key in `app.config`):

``` python
from flask.ext import components
for component in components.find('commands', app):
    for command in component.values():
        if (command and isinstance(command, type) and
                issubclass(command, (script.Command, script.Manager))):
            self.add_command(command)
```

If anyone is interested the above loop was implemented in alchemist: https://github.com/concordusapps/alchemist/blob/master/alchemist/management.py#L21-L26
