### PR TITLE
Repaired get_options function in the ShowUrls command to avoid conflicts with other commands

### DIFF
--- a/flask_script/commands.py
+++ b/flask_script/commands.py
@@ -390,16 +390,15 @@ class ShowUrls(Command):
         self.order = order
 
     def get_options(self):
-        options = super(ShowUrls, self).get_options()
-        options += Option('url',
-                          nargs='?',
-                          help='Url to test (ex. /static/image.png)',
-                          ),
-        options += Option('--order',
-                          dest='order',
-                          default=self.order,
-                          help='Property on Rule to order by (default: %s)' % self.order,
-                          ),
+        return (
+            Option('url',
+                   nargs='?',
+                   help='Url to test (ex. /static/image.png)'),
+            Option('--order',
+                   dest='order',
+                   default=self.order,
+                   help='Property on Rule to order by (default: %s)' % self.order)
+        )
 
         return options
 


### PR DESCRIPTION
Hey there Sean, hope you're doing well :smile: 

I discovered a rather nasty bug which is squashed with this commit.  The get_options function for the ShowUrls command was actually calling the super version of the function which was leading to conflicts with other commands.

You may reproduce the problem as follows...

**Example Script 1**

``` python
#!/usr/bin/env python
from flask import Flask
from flask.ext.script import Manager
from flask.ext.script.commands import ShowUrls, Clean

app = Flask(__name__)
manager = Manager(app)
manager.add_command('clean', Clean())
manager.add_command('urls', ShowUrls())

if __name__ == '__main__':
    manager.run()
```

Now run:

``` python
./manage1.py clean
```

The error output is shown below:

``` bash
(flask)fots@fotsies-ubprecise-01:~/flask/flaskage$ ./manage1.py clean
Traceback (most recent call last):
  File "./manage1.py", line 12, in <module>
    manager.run()
  File "/home/fots/.virtualenv/flask/local/lib/python2.7/site-packages/flask_script/__init__.py", line 405, in run
    result = self.handle(sys.argv[0], sys.argv[1:])
  File "/home/fots/.virtualenv/flask/local/lib/python2.7/site-packages/flask_script/__init__.py", line 384, in handle
    return handle(app, *positional_args, **kwargs)
  File "/home/fots/.virtualenv/flask/local/lib/python2.7/site-packages/flask_script/commands.py", line 145, in handle
    return self.run(*args, **kwargs)
TypeError: run() got an unexpected keyword argument 'url'
```

As you can see, what's happening here is the **run()** command for the **Clean** command class is seeing the **url** option from the **ShowUrls** class.

**Example Script 2**

``` python
#!/usr/bin/env python
from flask.ext.script.commands import ShowUrls, Clean

clean_command = Clean()

print ('clean_command args before ShowUrls: %r' %
       [c.args for c in clean_command.get_options()])

urls_command = ShowUrls()

print ('urls_command args after ShowUrls: %r' %
       [c.args for c in urls_command.get_options()])
print ('clean_command args after ShowUrls: %r' %
       [c.args for c in clean_command.get_options()])
```

And the output:

``` bash
(flask)fots@fotsies-ubprecise-01:~/flask/flaskage$ ./manage2.py
clean_command args before ShowUrls: []
urls_command args after ShowUrls: [('url',), ('--order',)]
clean_command args after ShowUrls: [('url',), ('--order',)]
```

This shows the problem even more clearly as the instance of the **Clean** command gets a different set of args after **ShowUrls** is imported and used.

Cheers
Fotis
