### PR TITLE
Add capability for sub-managers to manage their own options

### DIFF
--- a/flask_script/commands.py
+++ b/flask_script/commands.py
@@ -114,6 +114,7 @@ class Command(object):
 
     def create_parser(self, *args, **kwargs):
 
+        func_stack = kwargs.pop('func_stack',())
         parser = argparse.ArgumentParser(*args, **kwargs)
 
         for option in self.get_options():
@@ -132,9 +133,19 @@ class Command(object):
             else:
                 parser.add_argument(*option.args, **option.kwargs)
 
-        parser.set_defaults(func_handle=self.handle)
+        parser.set_defaults(func_stack=func_stack+(self,))
 
+        self.parser = parser
         return parser
+
+    def __call__(self, app=None, *args, **kwargs):
+        """
+        Compatibility code so that we can pass outselves to argparse
+        as `func_handle`, above.
+        The call to handle() is not replaced, so older code can still
+        override it.
+        """
+        return self.handle(app, *args, **kwargs)
 
     def handle(self, app, *args, **kwargs):
         """

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ if sys.version_info < (2, 7):
 
 setup(
     name='Flask-Script',
-    version='0.6.7',
+    version='0.7.0-dev',
     url='http://github.com/techniq/flask-script',
     license='BSD',
     author='Dan Jacob',


### PR DESCRIPTION
The first three patches in this series are mostly-obvious and hopefully self-explanatory. (I removed Flask from the test to show that flask-script does not require anything special from Flask.)

The fourth patch adds the capability for sub-managers to process their own command-line arguments. It also allows command options to have the same name as (sub)manager options, as long as the dest= values are different. It also allows a sub-manager to replace the current app with something else that's passed on to commands.

On the other hand, it takes away the ability to freely mix and match options and non-options. IMHO this was not a good idea in the first place; if nothing else, I want "manage.py --host foo config appserver --host=bar" to actually work, without being required to remember to use --config-host and --appserver-host or other strange "non-conflicting" option names. (Or in fact "-h" instead of "--host". Help is "-?" around here.) Because this is an incompatible change, this patch also increments the version number.

If you decide not to take this patch (or something like it), I'll probably maintain the change in my own fork.
