### PR TITLE
allow sub-manager tasks to use own app rather than parent's

### DIFF
--- a/flask_script/__init__.py
+++ b/flask_script/__init__.py
@@ -143,18 +143,20 @@ class Manager(object):
 
         If your sub-Manager does not override this, any values for options will get lost.
         """
-        if app is None:
-            app = self.app
+        if self.app is None:
             if app is None:
                 raise Exception("There is no app here. This is unlikely to work.")
+            self.app = app
+        elif app is not None:
+            kwargs['app'] = app
 
-        if isinstance(app, Flask):
+        if isinstance(self.app, Flask):
             if kwargs:
                 import warnings
                 warnings.warn("Options will be ignored.")
-            return app
+            return self.app
 
-        app = app(**kwargs)
+        app = self.app(**kwargs)
         self.app = app
         return app
 


### PR DESCRIPTION
it was hard for me to understand the logic in this method. i have tried to amend it to make the sub-manager task use its app rather than the parent's. all unit tests pass. perhaps another should be written to assert the correct app is used for default tasks.
