### PR TITLE
Fixed mangled runserver --reload help string

### DIFF
--- a/flask_script/commands.py
+++ b/flask_script/commands.py
@@ -390,7 +390,7 @@ class Server(Command):
             Option('-r', '--reload',
                    action='store_true',
                    dest='use_reloader',
-                   help='monitor Python files for changes (not 100% safe for production use)',
+                   help='monitor Python files for changes (not 100%% safe for production use)',
                    default=self.use_reloader),
             Option('-R', '--no-reload',
                    action='store_false',


### PR DESCRIPTION
argparse %-formats your help strings with a dictionary containing 'prog'
and a variety of other things. So '% s' is interpreted as "string,
padded with spaces to no minimum width".

Fixes #102.