### PR TITLE
Remove no-op import

### DIFF
--- a/flask_script/__init__.py
+++ b/flask_script/__init__.py
@@ -150,7 +150,6 @@ class Manager(object):
 
         if isinstance(app, Flask):
             if kwargs:
-                import warnings
                 warnings.warn("Options will be ignored.")
             return app
 


### PR DESCRIPTION
`warnings` imported at the top, so no need for the local import.