### PR TITLE
Access `add_subparsers()` kwargs

### DIFF
--- a/flask_script/__init__.py
+++ b/flask_script/__init__.py
@@ -77,6 +77,8 @@ class Manager(object):
                  help=None, description=None, disable_argcomplete=False):
 
         self.app = app
+        
+        self.subparser_kwargs = dict()
 
         self._commands = dict()
         self._options = list()
@@ -182,7 +184,7 @@ class Manager(object):
 
         self._patch_argparser(parser)
 
-        subparsers = parser.add_subparsers()
+        subparsers = parser.add_subparsers(**self.subparser_kwargs)
 
         for name, command in self._commands.items():
             usage = getattr(command, 'usage', None)


### PR DESCRIPTION
Specifically the ability to pass in things like the `metavar` keyword. It would be nice to just pass `metavar='COMMAND'` to `add_subparsers()` rather than getting using a list of all commands as a metavar. This looks really ugly when you have 10+ commands, and it's straining to fit them all into the `{,}` list.