### PR TITLE
Fixed code formatting and bad module references.

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -597,12 +597,12 @@ Error handling
 
 Users do not like to see stack traces, but developers want them for bug reports.
 
-Therefore, ``flask.ext.script.command`` provides an `InvalidCommand` error
+Therefore, ``flask.ext.script.commands`` provides an `InvalidCommand` error
 class which is not supposed to print a stack trace when reported.
 
-In your command handler:
+In your command handler::
 
-	from flask.ext.script.command import InvalidCommand
+    from flask.ext.script.commands import InvalidCommand
 
     [… if some command verification fails …]
     class MyCommand(Command):
@@ -610,7 +610,7 @@ In your command handler:
             if foo and bar:
 	            raise InvalidCommand("Options foo and bar are incompatible")
 
-In your main loop:
+In your main loop::
 
     try:
         MyManager().run()


### PR DESCRIPTION
Code was not formatted properly, needed to be introduced with double colon (::).
Fixed erroneous references to flask.ext.script.command (actually "commands").