### PR TITLE
work-around unexpected formatting of help text

### DIFF
--- a/flask_script/commands.py
+++ b/flask_script/commands.py
@@ -390,7 +390,7 @@ class Server(Command):
             Option('-r', '--reload',
                    action='store_true',
                    dest='use_reloader',
-                   help='monitor Python files for changes (not 100% safe for production use)',
+                   help='monitor Python files for changes (not completely safe for production use)',
                    default=self.use_reloader),
             Option('-R', '--no-reload',
                    action='store_false',


### PR DESCRIPTION
On my machine (Python 3.3.5), running ``python -m <webappmodule> runserver -?` gives the following output:

```console
$ python -m personalsite runserver -?
usage: __main__.py runserver [-?] [-h HOST] [-p PORT] [--threaded]
                             [--processes PROCESSES] [--passthrough-errors]
                             [-d] [-D] [-r] [-R]

Runs the Flask development server i.e. app.run()

optional arguments:
  -?, --help            show this help message and exit
  -h HOST, --host HOST
  -p PORT, --port PORT
  --threaded
  --processes PROCESSES
  --passthrough-errors
  -d, --debug           enable the Werkzeug debugger (DO NOT use in production
                        code)
  -D, --no-debug        disable the Werkzeug debugger
  -r, --reload          monitor Python files for changes (not 100{'container':
                        <argparse._ArgumentGroup object at 0x7f59df8f9190>,
                        'choices': None, 'metavar': None, 'dest':
                        'use_reloader', 'help': 'monitor Python files for
                        changes (not 100% safe for production use)', 'type':
                        None, 'required': False, 'default': None,
                        'option_strings': ['-r', '--reload'], 'const': True,
                        'nargs': 0, 'prog': '__main__.py runserver'}afe for
                        production use)
  -R, --no-reload       do not monitor Python files for changes
```

I suspect that the ``% s`` in ``100% safe`` is being interpreted as a formatting escape sequence. This PR includes a speculative work-around which doesn't fix the root problem but should stop the strange output.