### PR TITLE
fix misspelling. IPython <-> BPython

### DIFF
--- a/flask_script/commands.py
+++ b/flask_script/commands.py
@@ -260,12 +260,12 @@ class Shell(Command):
                 action="store_true",
                 dest='no_ipython',
                 default=not(self.use_ipython),
-                help="Do not use the BPython shell"),
+                help="Do not use the IPython shell"),
             Option('--no-bpython',
                 action="store_true",
                 dest='no_bpython',
                 default=not(self.use_bpython),
-                help="Do not use the IPython shell"),
+                help="Do not use the BPython shell"),
         )
 
     def get_context(self):


### PR DESCRIPTION
I find missspelled help message in `flask-script/command.py`and fixed it and PRed. Please check it. :)
--no-ipython's help: BPython -> IPython
--no-bpython's help: IPython -> BPython
