### PR TITLE
Change str.format() to support python 2.6

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -353,7 +353,7 @@ a command:
         if uppercase:
             name = name.upper()
             clue = clue.upper()
-        print "hello {}, get a {}!".format(name,clue)
+        print "hello {0}, get a {1}!".format(name,clue)
 
     > python manage.py -c dev.cfg hello -c cookie -n frank
     hello FRANK, get a COOKIE!

--- a/flask_script/__init__.py
+++ b/flask_script/__init__.py
@@ -383,7 +383,7 @@ class Manager(object):
             try:
                 res = handle(*args, **config)
             except TypeError as err:
-                err.args = ("{}: {}".format(handle,str(err)),)
+                err.args = ("{0}: {1}".format(handle,str(err)),)
                 raise
 
             args = [res]


### PR DESCRIPTION
While I can certainly sympathize with the fact that maintaining older version is a pain,  this is a very small change that enables the lib to be used with python 2.6 (tested with 2.6.6 at least).

This is especially important since CentOS 6 is still widely deployed and it's stuck with python 2.6, so we have no choice but to use it.
