### PR TITLE
Fix python3 unit tests.

### DIFF
--- a/tests.py
+++ b/tests.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+
 import re
 import sys
 import unittest


### PR DESCRIPTION
In python3 the unicode prefix is gone, so it's impossible to compare
a string representation in a compatible way.

Example of a failure:
E       assert "[u'pos1', u'pos2', u'--bar']" in "['pos1', 'pos2', '--bar']\n"
