### PR TITLE
Proper % escaping in help string

### DIFF
--- a/flask_script/commands.py
+++ b/flask_script/commands.py
@@ -390,7 +390,7 @@ class Server(Command):
             Option('-r', '--reload',
                    action='store_true',
                    dest='use_reloader',
-                   help='monitor Python files for changes (not 100% safe for production use)',
+                   help='monitor Python files for changes (not 100%% safe for production use)',
                    default=self.use_reloader),
             Option('-R', '--no-reload',
                    action='store_false',


### PR DESCRIPTION
Without this fix help output is:

    -r, --reload        monitor Python files for changes (not 100{'const':
                        True, 'help': 'monitor Python files for changes (not
                        100% safe for production use)', 'option_strings':
                        ['-r', '--reload'], 'dest': 'use_reloader',
                        'required': False, 'nargs': 0, 'choices': None,
                        'default': None, 'prog': 'manage.py runserver',
                        'container': <argparse._ArgumentGroup object at
                        0x1053d4a50>, 'type': None, 'metavar': None}afe for
                        production use)
