### PR TITLE
Fix Server --reload option help message

### DIFF
--- a/flask_script/commands.py
+++ b/flask_script/commands.py
@@ -390,7 +390,7 @@ class Server(Command):
             Option('-r', '--reload',
                    action='store_true',
                    dest='use_reloader',
-                   help='monitor Python files for changes (not 100% safe for production use)',
+                   help='monitor Python files for changes (not 100%% safe for production use)',
                    default=self.use_reloader),
             Option('-R', '--no-reload',
                    action='store_false',


### PR DESCRIPTION
It seems the help message for `runserver --reload` doesn't display properly due to the `%` in the text:
```
$ python3 manage.py runserver --help        
usage: manage.py runserver [-?] [-h HOST] [-p PORT] [--threaded]
                           [--processes PROCESSES] [--passthrough-errors] [-d]
                           [-D] [-r] [-R]

Runs the Flask development server i.e. app.run()

optional arguments:
  -?, --help            show this help message and exit
  -h HOST, --host HOST
  -p PORT, --port PORT
  --threaded
  --processes PROCESSES
  --passthrough-errors
  -d, --debug           enable the Werkzeug debugger (DO NOT use in production
                        code)
  -D, --no-debug        disable the Werkzeug debugger
  -r, --reload          monitor Python files for changes (not 100{'help':
                        'monitor Python files for changes (not 100% safe for
                        production use)', 'dest': 'use_reloader', 'default':
                        None, 'required': False, 'prog': 'manage.py
                        runserver', 'nargs': 0, 'container':
                        <argparse._ArgumentGroup object at 0x7fc083badfd0>,
                        'metavar': None, 'type': None, 'choices': None,
                        'const': True, 'option_strings': ['-r', '--
                        reload']}afe for production use)
  -R, --no-reload       do not monitor Python files for changes
```
