### PR TITLE
Fix iPython import exception: No module named 'IPython.Shell' by removing support for iPython < 0.12

### DIFF
--- a/flask_script/commands.py
+++ b/flask_script/commands.py
@@ -295,15 +295,8 @@ class Shell(Command):
         if not no_ipython:
             # Try IPython
             try:
-                try:
-                    # 0.10.x
-                    from IPython.Shell import IPShellEmbed
-                    ipshell = IPShellEmbed(banner=self.banner)
-                    ipshell(global_ns=dict(), local_ns=context)
-                except ImportError:
-                    # 0.12+
-                    from IPython import embed
-                    embed(banner1=self.banner, user_ns=context)
+                from IPython import embed
+                embed(banner1=self.banner, user_ns=context)
                 return
             except ImportError:
                 pass


### PR DESCRIPTION
Fixes #129 . Given that iPython 0.12 was released 4 years ago, removing support for earlier versions seems like a reasonable way to fix things.