### PR TITLE
fix the bpython lost flask app_context

### DIFF
--- a/flask_script/commands.py
+++ b/flask_script/commands.py
@@ -326,8 +326,8 @@ class Shell(Command):
         if not no_bpython:
             # Try BPython
             try:
-                from bpython import embed
-                embed(banner=self.banner, locals_=context)
+                from bpython.cli import main
+                main(['-i', '-q'], locals_=context, banner=self.banner)
                 return
             except ImportError:
                 pass


### PR DESCRIPTION
Reported as an issue here, https://github.com/smurfix/flask-script/issues/155#event-692155452.

Found it should be a bug of bpython (conflict with gevent) I reported here https://github.com/bpython/bpython/issues/620
but found another strange solution which import the bpython like this(see the code),  it'll work ok and won't lose the flask app_context.