### PR TITLE
Extract parameter help from docstrings

### DIFF
--- a/examples/manage.py
+++ b/examples/manage.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # PYTHON_ARGCOMPLETE_OK
 
+from __future__ import print_function
 import pprint
 
 from flask import Flask, current_app
@@ -11,7 +12,7 @@ from flask.ext.script.commands import ShowUrls, Clean
 def create_app(config=None):
     app = Flask(__name__)
     app.debug = False
-    print "CONFIG", config
+    print("CONFIG", config)
 
     app.config.from_envvar('APP_CONFIG', silent=True)
 
@@ -34,14 +35,14 @@ def dumpconfig():
 @manager.command
 def output(name):
     "print something"
-    print name
-    print type(name)
+    print(name)
+    print(type(name))
 
 
 @manager.command
 def outputplus(name, url=None):
     "print name and url"
-    print name, url
+    print(name, url)
 
 
 @manager.command
@@ -50,7 +51,7 @@ def getrolesimple():
     choices = ("member", "moderator", "admin")
 
     role = prompt_choices("role", choices=choices, default="member")
-    print "ROLE:", role
+    print("ROLE:", role)
 
 
 @manager.command
@@ -63,14 +64,14 @@ def getrole():
     )
 
     role = prompt_choices("role", choices=choices, resolve=int, default=1)
-    print "ROLE:", role
+    print("ROLE:", role)
 
 
 @manager.option('-n', '--name', dest='name', help="your name")
 @manager.option('-u', '--url', dest='url', help="your url")
 def optional(name, url):
     "print name and url"
-    print name, url
+    print(name, url)
 
 manager.add_option("-c", "--config",
                    dest="config",

--- a/flask_script/_compat.py
+++ b/flask_script/_compat.py
@@ -18,6 +18,7 @@ _identity = lambda x: x
 
 
 if not PY2:
+    # objects for Python >= 3
     unichr = chr
     range_type = range
     text_type = str
@@ -37,6 +38,8 @@ if not PY2:
             raise value.with_traceback(tb)
         raise value
 
+    from inspect import getfullargspec as getargspec
+
     ifilter = filter
     imap = map
     izip = zip
@@ -50,9 +53,10 @@ if not PY2:
     input = input
 
 else:
+    # objects for Python 2.7
     unichr = unichr
-    text_type = unicode
     range_type = xrange
+    text_type = unicode
     string_types = (str, unicode)
     integer_types = (int, long)
 
@@ -65,6 +69,8 @@ else:
     NativeStringIO = BytesIO
 
     exec('def reraise(tp, value, tb=None):\n raise tp, value, tb')
+
+    from inspect import getargspec
 
     from itertools import imap, izip, ifilter
     intern = intern
@@ -113,3 +119,5 @@ try:
     from urllib.parse import quote_from_bytes as url_quote
 except ImportError:
     from urllib import quote as url_quote
+
+__all__ = []

--- a/flask_script/commands.py
+++ b/flask_script/commands.py
@@ -147,7 +147,7 @@ class Command(object):
                 self.option_list = []
             return
 
-        args, varargs, keywords, defaults = inspect.getargspec(func)
+        args, varargs, keywords, defaults = getargspec(func)[:4]
         if inspect.ismethod(func):
             args = args[1:]
 


### PR DESCRIPTION
This adds a function to parse the docstring of command functions and which extracts Sphinx-style `:param the_parameter:` declarations which then get put into the help text provided with the corresponding argument