### PR TITLE
Fix ImportError on Python2.6

### DIFF
--- a/flask_script/__init__.py
+++ b/flask_script/__init__.py
@@ -7,7 +7,10 @@ import sys
 import types
 import warnings
 from gettext import gettext as _
-from collections import OrderedDict
+try:
+    from collections import OrderedDict
+except ImportError:
+    from ordereddict import OrderedDict
 
 import argparse
 


### PR DESCRIPTION
Hi,

We were using Flask-Script-2.0.5 earlier without an issue but due to recent dependancy change to version Flask-Script-2.0.6, we are now force to use newer version which does not work with Python2.6, We need support of Python2.6 for CentOS 6.

Details:
```
    import flask_migrate
  File "/var/lib/jenkins/workspace/py_code-master-python26/py_code-venv/lib/python2.6/site-packages/flask_migrate/__init__.py", line 4, in <module>
    from flask_script import Manager
  File "/var/lib/jenkins/workspace/py_code-master-python26/py_code-venv/lib/python2.6/site-packages/flask_script/__init__.py", line 10, in <module>
    from collections import OrderedDict
ImportError: cannot import name OrderedDict
```